### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: Make dist and run tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.12]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements.test.txt
+
+      - name: Run make_dist.py
+        run: python scripts/make_dist.py
+
+      - name: Run validator.py
+        run: python scripts/validator.py
+
+      - name: Run tests
+        run: tests/run_tests.sh
+
+      - name: Commit and push new ntrip-catalog.json
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add dist/ntrip-catalog.json
+          git commit -m "Auto-update ntrip-catalog.json" || echo "No changes to commit"
+          git push origin HEAD
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
-      - id: no-commit-to-branch
       - id: check-ast
       - id: check-merge-conflict
       # - id: check-yaml


### PR DESCRIPTION
Adds a GitHub Action to run some CI for PRs, and also on `master` after PRs merge.

1. Runs `scripts/make_dist.py`
2. Runs `scripts/validator.py`
3. Runs `tests/run_tests.sh`
4. Commits and pushes any updates to `ntrip-catalog.json` from step 1.

Some things to note:

- I removed the `no-commit-to-branch` rule from `pre-commit`. This was causing CI runs on `master` to fail. Plus, I don't think it's really necessary if branch protection is setup to require PRs to `master`. 
- The commit and push of the updated `ntrip-catalog.json` will _not_ trigger another run of CI, meaning it won't end up looping.