### PR TITLE
Use master for GitHub pages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 6.0.1
     hooks:
       - id: isort
         name: isort (python)

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,2 @@
 ntrip-catalog.org
+

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+ntrip-catalog.org

--- a/CNAME
+++ b/CNAME
@@ -1,2 +1,1 @@
 ntrip-catalog.org
-

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="refresh" content="2; url=https://github.com/Pix4D/ntrip-catalog" />
+    <title>NTRIP-catalog</title>
+  </head>
+  <body>
+    <main>
+        <h1>Welcome to the NTRIP-catalog</h1>
+        Redirecting to <a href="https://github.com/Pix4D/ntrip-catalog">https://github.com/Pix4D/ntrip-catalog</a>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
Adding `index.html` to master makes the page ntrip-catalog.org point to the updated data. Including the json schema that is linked in the json file.