### PR TITLE
Fix CI caching, split into two with common action

### DIFF
--- a/.github/workflows/ci-common.yml
+++ b/.github/workflows/ci-common.yml
@@ -1,0 +1,73 @@
+name: Shared CI Steps
+
+on:
+  workflow_call:
+    inputs:
+      commit_dist:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.12]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache pip and pre-commit
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.cache/pre-commit
+          key: ${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-py${{ matrix.python-version }}-
+
+      - name: Install dependencies
+        env:
+          PIP_NO_CACHE_DIR: "false"
+        run: |
+          pip install -r requirements.txt
+          pip install -r requirements.test.txt
+
+      # Install pre-commit hooks so they get cached
+      - name: Pre-warm pre-commit environments
+        run: |
+          if [ -f .pre-commit-config.yaml ]; then
+            pre-commit run --all-files --hook-stage manual || true
+          fi
+
+      - name: Build dist
+        run: python scripts/make_dist.py
+
+      - name: Validate dist
+        run: python scripts/validator.py
+
+      - name: Run tests
+        run: tests/run_tests.sh
+
+      - name: Commit and push dist if requested
+        if: ${{ inputs.commit_dist }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add dist/ntrip-catalog.json
+          if ! git diff --cached --quiet; then
+            git commit -m "Auto-update ntrip-catalog.json"
+            git push origin master
+          else
+            echo "No changes to commit"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,60 +1,10 @@
-name: Make dist and run tests
+name: CI Tests (PRs)
 
 on:
-  push:
-    branches: [master]
   pull_request:
-    branches: [master]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.12]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Cache pip
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libcurl4-openssl-dev
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements.test.txt
-
-      - name: Run make_dist.py
-        run: python scripts/make_dist.py
-
-      - name: Run validator.py
-        run: python scripts/validator.py
-
-      - name: Run tests
-        run: tests/run_tests.sh
-
-      - name: Commit and push new ntrip-catalog.json
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add dist/ntrip-catalog.json
-          if ! git diff-index --quiet HEAD; then
-            git commit -m "Auto-update ntrip-catalog.json"
-            git push origin HEAD
-          else
-            echo "No changes to commit"
-          fi
-
+  call-shared:
+    uses: ./.github/workflows/ci-common.yml
+    with:
+      commit_dist: false

--- a/.github/workflows/make-dist.yml
+++ b/.github/workflows/make-dist.yml
@@ -1,0 +1,14 @@
+name: Build and Commit Dist
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  call-shared:
+    uses: ./.github/workflows/ci-common.yml
+    with:
+      commit_dist: true
+
+permissions:
+  contents: write

--- a/dist/ntrip-catalog.json
+++ b/dist/ntrip-catalog.json
@@ -171,6 +171,7 @@
             "description": "Point One Navigation world service",
             "urls": [
                 "http://truertk.pointonenav.com:2101",
+                "http://test-remove-me.pointonenav.com:2101",
                 "http://virtualrtk.pointonenav.com:2101",
                 "http://truertk-us.pointonenav.com:2101",
                 "http://truertk-eu.pointonenav.com:2101",

--- a/dist/ntrip-catalog.json
+++ b/dist/ntrip-catalog.json
@@ -171,7 +171,6 @@
             "description": "Point One Navigation world service",
             "urls": [
                 "http://truertk.pointonenav.com:2101",
-                "http://test-remove-me.pointonenav.com:2101",
                 "http://virtualrtk.pointonenav.com:2101",
                 "http://truertk-us.pointonenav.com:2101",
                 "http://truertk-eu.pointonenav.com:2101",


### PR DESCRIPTION
# Changes
- Split CI into a few files:
  - `ci-common.yml`
    - This is what actually does everything, and contains the shared logic for both other files.
    - There is a `commit_dist` input now, which, if true, will commit and push changes to the `dist/ntrip-catalog.json`, if there were any.
    - I also fixed the caching, which reduces CI runtime from ~1m -> ~15s.
  - `ci.yml`
    - This runs only on PRs, and only runs tests. It _does not_ commit and push changes to `dist/ntrip-catalog.json`
  - `make-dist.yml`
    - This runs only on commits to master (merged PRs). It runs all the tests, just as `ci.yml`, but will also commit and push changes to `dist/ntrip-catalog.json`.

This is split from https://github.com/Pix4D/ntrip-catalog/pull/9.
