### PR TITLE
Add workflow_dispatch to manually run dist creation if needed

### DIFF
--- a/.github/workflows/ci-common.yml
+++ b/.github/workflows/ci-common.yml
@@ -67,7 +67,7 @@ jobs:
           git add dist/ntrip-catalog.json
           if ! git diff --cached --quiet; then
             git commit -m "Auto-update ntrip-catalog.json"
-            git push origin master
+            git push
           else
             echo "No changes to commit"
           fi

--- a/.github/workflows/manual-commit-dist.yml
+++ b/.github/workflows/manual-commit-dist.yml
@@ -1,0 +1,10 @@
+name: Manual CI Tests and Commit dist
+
+on:
+  workflow_dispatch:
+
+jobs:
+  call-ci-common:
+    uses: ./.github/workflows/ci-common.yml
+    with:
+      commit_dist: true


### PR DESCRIPTION
CI cannot add commits in master because it is protected.

Before merging a PR we should run this task manually. If the PR already  has dist created, this task will not do anything, so do not worry running again. Better twice than never!

The task is also executed in master on purpose. If dist was properly updated, it will not commit anything. If it has to commit something (and fail) it means that there is something wrong that has to be fixed.