### PR TITLE
Reduce friction for providers to contribute

### DIFF
--- a/.github/ISSUE_TEMPLATE/general.md
+++ b/.github/ISSUE_TEMPLATE/general.md
@@ -1,0 +1,19 @@
+---
+name: General Issue
+about: Report a problem, suggest an improvement, or ask a question
+title: ''
+labels: []
+assignees: ''
+---
+
+### Type of Issue
+<!-- What kind of issue is this? (bug report, feature request, question, etc.) -->
+
+### Description
+<!-- Describe your issue in detail -->
+
+### Additional Context
+<!-- Add any other context, screenshots, or relevant information -->
+
+### Documentation Reference
+<!-- If applicable, link to relevant documentation or sources -->

--- a/.github/ISSUE_TEMPLATE/ntrip-provider-submission.yml
+++ b/.github/ISSUE_TEMPLATE/ntrip-provider-submission.yml
@@ -88,7 +88,7 @@ body:
       label: Submission Confirmation
       description: Please confirm the following
       options:
-        - label: I confirm this information is accurate and officially documented
+        - label: I confirm this information is accurate and officially documented.
           required: true
         - label: I am authorized to submit this information on behalf of the network provider.
           required: true

--- a/.github/ISSUE_TEMPLATE/ntrip-provider-submission.yml
+++ b/.github/ISSUE_TEMPLATE/ntrip-provider-submission.yml
@@ -90,5 +90,5 @@ body:
       options:
         - label: I confirm this information is accurate and officially documented
           required: true
-        - label: I am authorized to submit this information on behalf of the network
+        - label: I am authorized to submit this information on behalf of the network provider.
           required: true

--- a/.github/ISSUE_TEMPLATE/ntrip-provider-submission.yml
+++ b/.github/ISSUE_TEMPLATE/ntrip-provider-submission.yml
@@ -1,0 +1,94 @@
+name: NTRIP Provider Submission
+description: Submit your NTRIP network information to the catalog
+title: "[NETWORK] Add "
+labels: ["provider-submission"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for contributing to the NTRIP catalog! This form will help you submit your network information.
+
+        Need help? Email us at `ntrip-catalog (at) ntrip-catalog.org`
+
+  - type: input
+    id: network-name
+    attributes:
+      label: Network Name
+      description: What is the name of your NTRIP network?
+      placeholder: e.g., NYSNet
+    validations:
+      required: true
+
+  - type: textarea
+    id: service-urls
+    attributes:
+      label: Service URLs
+      description: List all URLs/IPs where your service can be accessed (one per line)
+      placeholder: |
+        http://example-ntrip.com:2101
+        https://example-ntrip.com:2102
+    validations:
+      required: true
+
+  - type: dropdown
+    id: crs-type
+    attributes:
+      label: CRS Configuration
+      description: How is the Coordinate Reference System configured in your network?
+      options:
+        - Single CRS for all mountpoints
+        - Different CRS for different mountpoints
+        - CRS varies by region
+    validations:
+      required: true
+
+  - type: input
+    id: epsg-code
+    attributes:
+      label: EPSG Code
+      description: If using a single CRS, what EPSG code does your network use?
+      placeholder: e.g., EPSG:6319 for NAD83(2011)
+
+  - type: input
+    id: epoch
+    attributes:
+      label: Epoch
+      description: What epoch does your network use?
+      placeholder: e.g., 2010.00
+
+  - type: textarea
+    id: multiple-crs
+    attributes:
+      label: Multiple CRS Details
+      description: If using multiple CRS, please describe which mountpoints/regions use which CRS
+      placeholder: |
+        Region/Mountpoints | EPSG Code | Epoch
+        USA Mainland | EPSG:6318 | 2010.00
+        Hawaii | EPSG:6321 | 2010.00
+
+  - type: input
+    id: documentation
+    attributes:
+      label: Documentation URL
+      description: Please provide a link to where this CRS information is officially documented
+      placeholder: https://example.com/documentation
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Additional Information
+      description: Any additional details that might be helpful?
+      placeholder: e.g., Special considerations, network coverage details, etc.
+
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Submission Confirmation
+      description: Please confirm the following
+      options:
+        - label: I confirm this information is accurate and officially documented
+          required: true
+        - label: I am authorized to submit this information on behalf of the network
+          required: true

--- a/.github/ISSUE_TEMPLATE/ntrip-provider-submission.yml
+++ b/.github/ISSUE_TEMPLATE/ntrip-provider-submission.yml
@@ -1,6 +1,6 @@
 name: NTRIP Provider Submission
 description: Submit your NTRIP network information to the catalog
-title: "[NETWORK] Add "
+title: "Add [NETWORK] to the NTRIP catalog"
 labels: ["provider-submission"]
 body:
   - type: markdown

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ For networks spanning multiple regions where CRS varies by location.
 **Example:** [Point One Nav](https://github.com/Pix4D/ntrip-catalog/blob/master/data/World/pointonenav.json)
 
 Two ways to specify regions:
-1. **By Country** (`rover_countries`):
+1. **By country** (`rover_countries`):
    - Use [3-letter ISO country codes](https://countrycode.org/)
    - Best for country-specific CRS definitions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ To add your NTRIP service to the catalog, we need:
 
 3. **Documentation Reference**:
    - Link to official documentation or webpage where this CRS information is published
-   - This helps maintain the catalog's reliability
+   - NTRIP catalog is intended to be a trustworthy source of information. It's therefore a requirement to provide an official reference in order to merge a submission.
 
 ## Making a Pull Request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ Many regional networks use the same CRS for all mountpoints. This is the simples
 
 **Example:** [NYSNet Network](https://github.com/Pix4D/ntrip-catalog/blob/master/data/World/Americas/USA/nysnet.json)
 - All mountpoints use NAD83(2011)
-- Single JSON entry covers all URLs and mountpoints
+- A single JSON entry covers all the URLs and mountpoints
 - Perfect starting point for many providers
 
 ### 2. Multiple CRS: Different Mountpoints, Different CRS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ Two ways to specify regions:
    - Use [3-letter ISO country codes](https://countrycode.org/)
    - Best for country-specific CRS definitions
 
-2. **By Region** (`rover_bbox`):
+2. **By region area** (`rover_bbox`):
    - Uses bounding boxes for specific regions
    - Perfect for regions that differ from their country's standard
    - Example: Hawaii using NAD83(PA11) vs mainland USA using NAD83(2011)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,26 +1,86 @@
 # Contributing
 
-## Who can contribute?
-Anybody is welcome to contribute to this catalog, but ideally we expect NTRIP providers to submit their data themselves.
-If you find the proper documentation published by the NTRIP provider confirming the CRS used, and do not expect the provider to do it, you can contribute it as well.
-Notice that any contribution should be properly documented, filling the `reference` section in the json file.
+## NTRIP Provider Quick Start
 
-## How to contribute
-Just create a PR in this GitHub project.
-In case you do not know how to do it, or you do not feel comfortable with JSON, you can open an Issue providing all the data.
-All contributions must be properly documented, filling the `reference` section in the JSON file.
-This database is intended to become a trusted source of information,
-therefore submissions that cannot be backed by an authoritative reference will not be considered.
-Any new entry should be added to the appropriate country/region-specific file below the `data` folder. Existing entries in this folder can be used as an example and starting point.
+We welcome contributions from NTRIP providers to help make this catalog as accurate and comprehensive as possible. There are two easy ways to contribute:
 
-Do not forget to update the file `data/release.txt` increasing the release number.
-Pay special attention in case you have to [rebase](https://git-scm.com/docs/git-rebase) from master.
+1. **Create an Issue (Simplest)**:
+   - Create a [new issue](https://github.com/pix4d/ntrip-catalog/issues/new)
+   - You'll need a free GitHub account
+   - Fill out the template with your NTRIP service information
+   - We'll handle creating the proper JSON file for you
 
-All contributions to NTRIP-catalog are subject to the Developer Certificate of Origin (DCO, https://developercertificate.org/).
+2. **Submit a Pull Request (Advanced)**:
+   - Fork the repository
+   - Add your service information
+   - Submit a pull request
 
-All contributions must be signed off in the form of a `Signed-off-by: Random J Developer <random@developer.example.org>` line at the end of each commit message, using the contributor's real name and email address.
-By signing off, the contributor agrees to the DCO.
-The line will be added automatically when using the `git commit -s` command.
+## What We Need
 
-## How to report errors
-In case you find any error you can either make a Pull Request or write an email to `ntrip-catalog (at) ntrip-catalog.org`
+To add your NTRIP service to the catalog, we need:
+
+1. **Basic Service Information**:
+   - Service name
+   - Service URL(s) including protocol (`http`, `https`) and port
+   - List of mountpoints, and the CRS that each uses
+
+2. **CRS Information**:
+   - The Coordinate Reference System(s) used by your service
+   - EPSG code
+   - Epoch
+   - If different regions use different CRS, please specify
+
+3. **Documentation Reference**:
+   - Link to official documentation or webpage where this CRS information is published
+   - This helps maintain the catalog's reliability
+
+## Making a Pull Request
+
+If you're comfortable with GitHub and JSON, here's how to submit a PR:
+
+1. Add your service information to the appropriate country file in the `data` folder
+2. Update `data/release.txt` with an incremented version number
+3. Sign your commits with the Developer Certificate of Origin (DCO):
+   ```bash
+   git commit -s -m "Your commit message"
+   ```
+
+The DCO signature certifies that you have the right to submit this contribution. It will be automatically added when using the `-s` flag.
+
+## Examples
+
+We have three common scenarios for NTRIP networks. Below are examples for each case:
+
+### 1. Simple: Single CRS for All Mountpoints
+Many regional networks use the same CRS for all mountpoints. This is the simplest case.
+
+**Example:** [NYSNet Network](https://github.com/Pix4D/ntrip-catalog/blob/master/data/World/Americas/USA/nysnet.json)
+- All mountpoints use NAD83(2011)
+- Single JSON entry covers all URLs and mountpoints
+- Perfect starting point for many providers
+
+### 2. Multiple CRS: Different Mountpoints, Different CRS
+Some networks offer mountpoints in different coordinate systems.
+
+**Example:** [MnCORS Network](https://github.com/Pix4D/ntrip-catalog/blob/master/data/World/Americas/USA/mncors.json)
+- Some mountpoints use NAD83(2011)
+- Others use NAD83(CORS96)
+- Each CRS group is defined in its own stream
+
+### 3. Advanced: Region-Based CRS Selection
+For networks spanning multiple regions where CRS varies by location.
+
+**Example:** [Point One Nav](https://github.com/Pix4D/ntrip-catalog/blob/master/data/World/pointonenav.json)
+
+Two ways to specify regions:
+1. **By Country** (`rover_countries`):
+   - Use [3-letter ISO country codes](https://countrycode.org/)
+   - Best for country-specific CRS definitions
+
+2. **By Region** (`rover_bbox`):
+   - Uses bounding boxes for specific regions
+   - Perfect for regions that differ from their country's standard
+   - Example: Hawaii using NAD83(PA11) vs mainland USA using NAD83(2011)
+   - Important: List region-specific entries before country-wide ones
+
+Need help? Email us at `ntrip-catalog (at) ntrip-catalog.org`


### PR DESCRIPTION
## Why?
In the interest of reducing friction for NTRIP providers to contribute their data, I've simplified CONTRIBUTING.md, added examples to it, and added an issue templates that should guide providers through the process of contributing their info to the catalog.

Notably, this more highly encourages providers to just create an issue, which we'd then flesh out in JSON. Sure, this is more work for maintainers, but I think it's better to have providers make issues themselves, rather than not contribute at all. Of course, if the workload is too high as a result of this (which I doubt), we can always change it later.

_Note_: These issue templates will work out of the box after this is on master. Try them out on [my fork](https://github.com/bscholer/ntrip-catalog/issues)

## Walkthrough
https://www.loom.com/share/79b54b95968c4470a701ffb2c8d3acea?sid=e0774fcc-0e4f-46d4-932f-3992b4e1ff4f