### PR TITLE
add some needed headers to pycurl requests

### DIFF
--- a/scripts/query.py
+++ b/scripts/query.py
@@ -24,6 +24,8 @@ def get_streams_from_server(url):
     curl.setopt(pycurl.URL, url)
     curl.setopt(pycurl.TIMEOUT, 10)
     curl.setopt(pycurl.CONNECTTIMEOUT, 3)
+    curl.setopt(pycurl.HTTP09_ALLOWED, True)
+    curl.setopt(pycurl.HTTP_VERSION, pycurl.CURL_HTTP_VERSION_1_1)
     curl.setopt(pycurl.WRITEFUNCTION, sio.write)
     curl.setopt(
         pycurl.HTTPHEADER, ["Ntrip-Version: Ntrip/2.0", "User-Agent: NTRIPClient/1.0"]
@@ -38,10 +40,10 @@ def get_streams_from_server(url):
             return sio.getvalue().decode("iso-8859-1").splitlines()
 
     except pycurl.error as e:
-        logger.error("pycurl exception", e)
+        logger.error("pycurl exception " + str(e))
         raise pycurl.error(e)
     except Exception as e:
-        logger.error("exception", e)
+        logger.error("exception " + str(e))
         raise Exception(e)
 
 

--- a/tests/test_codes_consistency.py
+++ b/tests/test_codes_consistency.py
@@ -1,8 +1,7 @@
 import json
 import urllib.error
 import urllib.request
-
-import pytest
+import warnings
 
 from scripts import query as ntrip_query
 
@@ -15,9 +14,12 @@ def download_crslist():
     return crslist
 
 
-@pytest.mark.xfail(raises=urllib.error.HTTPError)
 def test_codes():
-    crslist = download_crslist()  # this may fail because it is an http request.
+    try:
+        crslist = download_crslist()  # this may fail because it is an http request.
+    except urllib.error.HTTPError as e:
+        warnings.warn(UserWarning("exception " + str(e)))
+        return
 
     def testit(id, name):
         id_exists = False

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,40 +1,68 @@
-import pytest
+import warnings
+
+import pycurl
 
 from scripts import query as ntrip_query
 
 
-@pytest.mark.xfail
 def test_spain_ign_2101():
-    url = "http://ergnss-tr.ign.es:2101"
+    try:
+        url = "http://ergnss-tr.ign.es:2101"
+        json_data = ntrip_query.load_json()
+        entry = ntrip_query.search_url_in_data(url, json_data)
+        assert entry
+
+        mountpoint = "CERCANA3"
+        crs = ntrip_query.filter_crs(entry, url, mountpoint, 40, -1.5)
+        assert crs
+        assert crs["id"] == "EPSG:7931"
+        assert crs["name"] == "ETRF2000"
+
+        crs = ntrip_query.filter_crs(entry, url, mountpoint, 28, -16)
+        assert crs
+        assert crs["id"] == "EPSG:4080"
+        assert crs["name"] == "REGCAN95"
+    except pycurl.error as e:
+        warnings.warn(UserWarning("pycurl exception " + str(e)))
+
+
+def test_spain_ign_2102():
+    url = "http://ergnss-tr.ign.es:2102"
     json_data = ntrip_query.load_json()
     entry = ntrip_query.search_url_in_data(url, json_data)
     assert entry
 
-    mountpoint = "CERCANA3"
-    crs = ntrip_query.filter_crs(entry, url, mountpoint, 40, -1.5)
-    assert crs
-    assert crs["id"] == "EPSG:7931"
-    assert crs["name"] == "ETRF2000"
+    try:
+        mountpoint = "IGNE3M"  # Madrid - IGN
+        crs = ntrip_query.filter_crs(entry, url, mountpoint, 40, -1.5)
+        assert crs
+        assert crs["id"] == "EPSG:7931"
+        assert crs["name"] == "ETRF2000"
 
-    crs = ntrip_query.filter_crs(entry, url, mountpoint, 28, -16)
-    assert crs
-    assert crs["id"] == "EPSG:4080"
-    assert crs["name"] == "REGCAN95"
+        mountpoint = "IZAN3M"  # Izana, Tenerife
+        crs = ntrip_query.filter_crs(entry, url, mountpoint, 28, -16)
+        assert crs
+        assert crs["id"] == "EPSG:4080"
+        assert crs["name"] == "REGCAN95"
+    except pycurl.error as e:
+        warnings.warn(UserWarning("pycurl exception " + str(e)))
 
 
-@pytest.mark.xfail
 def test_vrsnow_de_2101_countries():
-    url = "http://vrsnow.de:2101"
-    json_data = ntrip_query.load_json()
-    entry = ntrip_query.search_url_in_data(url, json_data)
-    assert entry
+    try:
+        url = "http://vrsnow.de:2101"
+        json_data = ntrip_query.load_json()
+        entry = ntrip_query.search_url_in_data(url, json_data)
+        assert entry
 
-    crs = ntrip_query.filter_crs(entry, url, "TVN_RTCM_31", 0, 0)
-    assert crs
-    assert crs["id"] == "EPSG:10283"
-    assert crs["name"] == "ETRS89/DREF91/2016"
+        crs = ntrip_query.filter_crs(entry, url, "TVN_RTCM_31", 0, 0)
+        assert crs
+        assert crs["id"] == "EPSG:10283"
+        assert crs["name"] == "ETRS89/DREF91/2016"
 
-    crs = ntrip_query.filter_crs(entry, url, "TVN_CMR_X_GPS_GLO", 0, 0)
-    assert crs
-    assert crs["id"] == "EPSG:10283"
-    assert crs["name"] == "ETRS89/DREF91/2016"
+        crs = ntrip_query.filter_crs(entry, url, "TVN_CMR_X_GPS_GLO", 0, 0)
+        assert crs
+        assert crs["id"] == "EPSG:10283"
+        assert crs["name"] == "ETRS89/DREF91/2016"
+    except pycurl.error as e:
+        warnings.warn(UserWarning("pycurl exception " + str(e)))


### PR DESCRIPTION
Some servers need http 0.9. (like IGN in Spain)
Others need http 1.1 (like https pointonenav)

Improve the tests to not fail in pycurl.error, (just raise a warning) but fail on anything else.
