### PR TITLE
Speed up pytest collecting tests

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -13,4 +13,4 @@ pre-commit run --file $LOCALPATH/**/*
 python3 -W ignore::DeprecationWarning $LOCALPATH/scripts/validator.py --log-input-files --no-validate-dist
 python3 -W ignore::DeprecationWarning $LOCALPATH/scripts/validator.py --log-input-files --validate-dist
 
-pytest
+pytest $LOCALPATH/tests/


### PR DESCRIPTION
`pytest` is taking a long time scanning all the folders. We are only interested on the actual tests in the tests directory.