### PR TITLE
Add macors.json

### DIFF
--- a/data/World/Americas/USA/macors.json
+++ b/data/World/Americas/USA/macors.json
@@ -1,0 +1,23 @@
+{
+    "name": "MACORS",
+    "description": "Massachusetts Continuously Operating Reference Station Network",
+    "urls": [
+        "http://macorsrtk.massdot.state.ma.us:10000"
+    ],
+    "reference": {
+        "url": "https://www.mass.gov/how-to/the-massachusetts-continuously-operating-reference-station-network-macors"
+    },
+    "last_update": "2025-12-02",
+    "streams": [
+        {
+            "filter": "all",
+            "crss": [
+                {
+                    "id": "EPSG:6319",
+                    "name": "NAD83(2011)",
+                    "epoch": 2010.0
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Pretty simple and straightforward.
Find all the relevant information [here](https://macors.massdot.state.ma.us/MyPages/Docs/MaCORS_FAQs_Rev8.pdf)


Ntrip caster URL:
> What is the required IP address for a real-time network connection?
> The proxy server URL is: macorsrtk.massdot.state.ma.us
> Using the URL is preferable since you will not be affected by any future IP address changes.
> However, the IP address may be provided on request for persons with legacy equipment.

CRS:
> What is the established MaCORS datum?
> The established datum for MaCORS is NAD 83 (2011) (Epoch 2010.00).


