### PR TITLE
Add example for migration to NATRF2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ It would be nice if you ask your service provider, inviting them to complete thi
 In case there is an entry for your service, but no proper data is found, please ask the NTRIP provider to complete it with a pull-request.
 
 ## Examples
-[Here](example-natrf2022.md) shows how a provider can specify an NTRIP service offering both `NAD83(2011)` and `NATRF2022`.
+[This page](example-natrf2022.md) shows how a provider can specify an NTRIP service offering both `NAD83(2011)` and `NATRF2022`.
 
 ## Contributing
 If you would like to contribute to this project, please read the file [CONTRIBUTING_GUIDE.md](CONTRIBUTING_GUIDE.md).

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ It would be nice if you ask your service provider, inviting them to complete thi
 
 In case there is an entry for your service, but no proper data is found, please ask the NTRIP provider to complete it with a pull-request.
 
+## Examples
+[Here](example-natrf2022.md) you can see an example to show the difference between `NAD83(2011)` and `NATRF2022` depending on your configuration.
+
 ## Contributing
 If you would like to contribute to this project, please read the file [CONTRIBUTING_GUIDE.md](CONTRIBUTING_GUIDE.md).
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ It would be nice if you ask your service provider, inviting them to complete thi
 In case there is an entry for your service, but no proper data is found, please ask the NTRIP provider to complete it with a pull-request.
 
 ## Examples
-[Here](example-natrf2022.md) you can see an example to show the difference between `NAD83(2011)` and `NATRF2022` depending on your configuration.
+[Here](example-natrf2022.md) shows how a provider can specify an NTRIP service offering both `NAD83(2011)` and `NATRF2022`.
 
 ## Contributing
 If you would like to contribute to this project, please read the file [CONTRIBUTING_GUIDE.md](CONTRIBUTING_GUIDE.md).

--- a/example-natrf2022.md
+++ b/example-natrf2022.md
@@ -4,6 +4,11 @@ During the adoption of the Modernized NSRS in the USA, Canada and Mexico, there 
 NTRIP providers will provide the service for the "old" and the "new" CRS during the transition period.
 [NTRIP-catalog](https://ntrip-catalog.org) can help to automatically identify it, making the transition soft and easy.
 
+The misalignment of the earth's center [by 2.2 meters](https://geodesy.noaa.gov/datums/newdatums/) in NAD83(2011)
+make differences between 1 and 2 meters (3 to 6 feet) between NAD83(2011) and NATRF2022.
+That is not small, but not huge that would allow the user to notice it immediately.
+It is in the order of magnitude of many other errors, making it difficult to identify.
+
 These examples for the transition from `NAD83(2011)` to `NATRF2022` in the USA [https://beta.ngs.noaa.gov/](https://beta.ngs.noaa.gov/) show how easy it is to identify them properly.
 
 There are several options to make the difference. Here we show the two main ones:
@@ -11,6 +16,11 @@ There are several options to make the difference. Here we show the two main ones
  - Use different port (or even URL) for the new CRS
 
 ## Example using different mountpoints
+
+Some providers will add more mountpoints to the existing ones.
+The names make the difference between the CRSs.
+Filtering by mountpoint name easily allow to differenciate the CRSs
+
 ```json
 {
     "name": "RTK Sample",
@@ -68,6 +78,11 @@ There are several options to make the difference. Here we show the two main ones
 ```
 
 ## Example using different ports
+
+Some providers will create a new access point, using a different port or even a differenct hostname.
+This is probably useful if the list of mountpoints is already large, not making it even larger.
+In that case the configuration is straigt forward, just adding a new URL with its data.
+
 ```json
 [
     {

--- a/example-natrf2022.md
+++ b/example-natrf2022.md
@@ -1,6 +1,7 @@
 # Example for NATRF2022
 
-During the transition period until the Modernized NSRS in the USA, Canada and Mexico is fully adopted, NTRIP providers will have to provide corrections for the "old" and the "new" CRSs. This will inevitably cause confusion as to which CRS is the correct one to use with given NTRIP mount point.
+During the transition period until the Modernized NSRS in the USA, Canada and Mexico is fully adopted, NTRIP providers will have to provide corrections for the "old" and the "new" CRSs.
+This will inevitably cause confusion as to which CRS is the correct one to use with given NTRIP mountpoint.
 
 [NTRIP-catalog](https://ntrip-catalog.org) can help to automatically identify it, making the transition smooth and painless.
 

--- a/example-natrf2022.md
+++ b/example-natrf2022.md
@@ -1,25 +1,26 @@
 # Example for NATRF2022
 
-During the adoption of the Modernized NSRS in the USA, Canada and Mexico, there can be confusion about the CRS used for the corrections.
-NTRIP providers will provide the service for the "old" and the "new" CRS during the transition period.
+During the transition period until the Modernized NSRS in the USA, Canada and Mexico is fully adopted, NTRIP providers will have to provide corrections for the "old" and the "new" CRS during the transition period. This will inevitably cause confusion about which is the correct CRS to use with a given NTRIP mount point.
+
 [NTRIP-catalog](https://ntrip-catalog.org) can help to automatically identify it, making the transition soft and easy.
 
 The misalignment of the earth's center [by 2.2 meters](https://geodesy.noaa.gov/datums/newdatums/) in NAD83(2011)
 make differences between 1 and 2 meters (3 to 6 feet) between NAD83(2011) and NATRF2022.
-That is not small, but not huge that would allow the user to notice it immediately.
-It is in the order of magnitude of many other errors, making it difficult to identify.
+While the difference is not small, it is in the order of magnitude of many other errors, make it difficult for users to notice configuration errors immediately.
 
-These examples for the transition from `NAD83(2011)` to `NATRF2022` in the USA [https://beta.ngs.noaa.gov/](https://beta.ngs.noaa.gov/) show how easy it is to identify them properly.
+[NTRIP-catalog](https://ntrip-catalog.org) can help avoid configuration errors in the first place, as it can be used to select the correct CRS automatically based on the client device configuration (URL, port, mountpoint, position, ...)
 
-There are several options to make the difference. Here we show the two main ones:
- - Use different mountpoints in the same URL:port
- - Use different port (or even URL) for the new CRS
+These examples for the transition from `NAD83(2011)` to `NATRF2022` in the USA [https://beta.ngs.noaa.gov/](https://beta.ngs.noaa.gov/) show how easy it is to specify a service providing both systems allowing automatic client selection.
+
+The NTRIP-catalog schema provides several methods to specify NTRIP services offered in multiple CRSs by the same provider. Here we show the two main ones:
+ - Use different mountpoints in the same URL
+ - Use different ports (or even hostnames) for the each CRS
 
 ## Example using different mountpoints
 
 Some providers will add more mountpoints to the existing ones.
 The names make the difference between the CRSs.
-Filtering by mountpoint name easily allow to differenciate the CRSs
+Filtering by mountpoint name easily allows to choose the correct CRS.
 
 ```json
 {
@@ -80,8 +81,8 @@ Filtering by mountpoint name easily allow to differenciate the CRSs
 ## Example using different ports
 
 Some providers will create a new access point, using a different port or even a differenct hostname.
-This is probably useful if the list of mountpoints is already large, not making it even larger.
-In that case the configuration is straigt forward, just adding a new URL with its data.
+This is probably useful to not extend mountpoint lists which are already very long.
+In that case the configuration is straightforward, just adding a new URL with its data.
 
 ```json
 [

--- a/example-natrf2022.md
+++ b/example-natrf2022.md
@@ -83,7 +83,7 @@ Filtering by mountpoint name easily allows to choose the correct CRS.
 
 ## Example using different ports
 
-Some providers will create a new access point, using a different port or even a differenct hostname.
+Some providers will create a new access point, using a different port or even a different hostname.
 This is probably useful to not extend mountpoint lists which are already very long.
 In that case the configuration is straightforward, just adding a new URL with its data.
 

--- a/example-natrf2022.md
+++ b/example-natrf2022.md
@@ -16,6 +16,9 @@ The NTRIP-catalog schema provides several methods to specify NTRIP services offe
  - Use different mountpoints in the same URL
  - Use different ports (or even hostnames) for the each CRS
 
+Do not wait for `NATRF2022` (and its siblings `PATRF2022`, `CATRF2022` and `MATRF2022`) to be officially released.
+You can include the configuration for `NAD83(2011)` now, and update it once you know the new data.
+
 ## Example using different mountpoints
 
 Some providers will add more mountpoints to the existing ones.

--- a/example-natrf2022.md
+++ b/example-natrf2022.md
@@ -1,11 +1,11 @@
 # Example for NATRF2022
 
-During the transition period until the Modernized NSRS in the USA, Canada and Mexico is fully adopted, NTRIP providers will have to provide corrections for the "old" and the "new" CRS during the transition period. This will inevitably cause confusion about which is the correct CRS to use with a given NTRIP mount point.
+During the transition period until the Modernized NSRS in the USA, Canada and Mexico is fully adopted, NTRIP providers will have to provide corrections for the "old" and the "new" CRSs. This will inevitably cause confusion as to which CRS is the correct one to use with given NTRIP mount point.
 
-[NTRIP-catalog](https://ntrip-catalog.org) can help to automatically identify it, making the transition soft and easy.
+[NTRIP-catalog](https://ntrip-catalog.org) can help to automatically identify it, making the transition smooth and painless.
 
 The misalignment of the earth's center [by 2.2 meters](https://geodesy.noaa.gov/datums/newdatums/) in NAD83(2011)
-make differences between 1 and 2 meters (3 to 6 feet) between NAD83(2011) and NATRF2022.
+makes differences between 1 and 2 meters (3 to 6 feet) between NAD83(2011) and NATRF2022.
 While the difference is not small, it is in the order of magnitude of many other errors, making it difficult for users to notice configuration errors immediately.
 
 [NTRIP-catalog](https://ntrip-catalog.org) can help avoid configuration errors in the first place, as it can be used to select the correct CRS automatically based on the client device configuration (URL, port, mountpoint, position, ...)
@@ -17,13 +17,13 @@ The NTRIP-catalog schema provides several methods to specify NTRIP services offe
  - Use different ports (or even hostnames) for each CRS
 
 There is no need to wait for `NATRF2022` (and its siblings `PATRF2022`, `CATRF2022` and `MATRF2022`) to be officially released.
-You can include the configuration for `NAD83(2011)` now, and update it to include the new mount points once they are released and you know the new data.
+You can include the configuration for `NAD83(2011)` now, and update it to include the new mountpoints once they are released and you know the new data.
 
-## Example using different mountpoints
+## Using different mountpoints
 
 Some providers will add more mountpoints to the existing ones.
-The names make the difference between the CRSs.
-Filtering by mountpoint name easily allows clients to choose the correct CRS.
+The names distinguish between the CRSs.
+Filtering by mountpoint name allows clients to choose the correct CRS easily.
 
 ```json
 {
@@ -83,9 +83,9 @@ Filtering by mountpoint name easily allows clients to choose the correct CRS.
 
 ## Example using different ports
 
-Some providers will create a new access point, using a different port or even a different hostname.
-This is probably useful to not extend mountpoint lists which are already very long.
-In that case the configuration is straightforward, just adding a new URL with its data.
+Some providers will create a new access point using a different port or even a different hostname.
+It is probably better to not extend mountpoint lists which are already very long.
+In that case, the configuration is straightforward: just add a new URL with its data.
 
 ```json
 [

--- a/example-natrf2022.md
+++ b/example-natrf2022.md
@@ -6,24 +6,24 @@ During the transition period until the Modernized NSRS in the USA, Canada and Me
 
 The misalignment of the earth's center [by 2.2 meters](https://geodesy.noaa.gov/datums/newdatums/) in NAD83(2011)
 make differences between 1 and 2 meters (3 to 6 feet) between NAD83(2011) and NATRF2022.
-While the difference is not small, it is in the order of magnitude of many other errors, make it difficult for users to notice configuration errors immediately.
+While the difference is not small, it is in the order of magnitude of many other errors, making it difficult for users to notice configuration errors immediately.
 
 [NTRIP-catalog](https://ntrip-catalog.org) can help avoid configuration errors in the first place, as it can be used to select the correct CRS automatically based on the client device configuration (URL, port, mountpoint, position, ...)
 
-These examples for the transition from `NAD83(2011)` to `NATRF2022` in the USA [https://beta.ngs.noaa.gov/](https://beta.ngs.noaa.gov/) show how easy it is to specify a service providing both systems allowing automatic client selection.
+These examples for the transition from `NAD83(2011)` to `NATRF2022` in the USA [https://beta.ngs.noaa.gov/](https://beta.ngs.noaa.gov/) show how easy it is to specify a service providing both systems, allowing automatic client selection.
 
 The NTRIP-catalog schema provides several methods to specify NTRIP services offered in multiple CRSs by the same provider. Here we show the two main ones:
  - Use different mountpoints in the same URL
- - Use different ports (or even hostnames) for the each CRS
+ - Use different ports (or even hostnames) for each CRS
 
-Do not wait for `NATRF2022` (and its siblings `PATRF2022`, `CATRF2022` and `MATRF2022`) to be officially released.
-You can include the configuration for `NAD83(2011)` now, and update it once you know the new data.
+There is no need to wait for `NATRF2022` (and its siblings `PATRF2022`, `CATRF2022` and `MATRF2022`) to be officially released.
+You can include the configuration for `NAD83(2011)` now, and update it to include the new mount points once they are released and you know the new data.
 
 ## Example using different mountpoints
 
 Some providers will add more mountpoints to the existing ones.
 The names make the difference between the CRSs.
-Filtering by mountpoint name easily allows to choose the correct CRS.
+Filtering by mountpoint name easily allows clients to choose the correct CRS.
 
 ```json
 {

--- a/example-natrf2022.md
+++ b/example-natrf2022.md
@@ -1,0 +1,120 @@
+# Example for NATRF2022
+
+During the adoption of the Modernized NSRS in the USA, Canada and Mexico, there can be confusion about the CRS used for the corrections.
+NTRIP providers will provide the service for the "old" and the "new" CRS during the transition period.
+[NTRIP-catalog](https://ntrip-catalog.org) can help to automatically identify it, making the transition soft and easy.
+
+These examples for the transition from `NAD83(2011)` to `NATRF2022` in the USA [https://beta.ngs.noaa.gov/](https://beta.ngs.noaa.gov/) show how easy it is to identify them properly.
+
+There are several options to make the difference. Here we show the two main ones:
+ - Use different mountpoints in the same URL:port
+ - Use different port (or even URL) for the new CRS
+
+## Example using different mountpoints
+```json
+{
+    "name": "RTK Sample",
+    "description": "Service in port 8000 for both NAD83(2011) and NATRF2022",
+    "urls": [
+        "http://rtk.example.com:8000"
+    ],
+    "reference": {
+        "url": "http://rtk.example.com/info"
+    },
+    "last_update": "2026-01-23",
+    "streams": [
+        {
+            "filter": {
+                "mountpoints": [
+                    "FKP3",
+                    "FKP3M",
+                    "MAC3",
+                    "MAC3M",
+                    "VRS3",
+                    "VRS3M"
+                ]
+            },
+            "crss": [
+                {
+                    "id": "EPSG:6319",
+                    "name": "NAD83(2011)",
+                    "epoch": 2010.0
+                }
+            ],
+            "description": "NAD83(2011)",
+            "comments": "These mountpoints will be deprecated in 2028"
+        },
+        {
+            "filter": {
+                "mountpoints": [
+                    "MAC3NATRF",
+                    "MAC3MNATRF",
+                    "VRS3NATRF",
+                    "VRS3MNATRF"
+                ]
+            },
+            "crss": [
+                {
+                    "id": "EPSG:10967",
+                    "name": "NATRF2022",
+                    "epoch": 2020.0
+                }
+            ],
+            "description": "NATRF2022 from the Modernized NSRS in CONUS",
+            "comments": "Added in 2026"
+        }
+    ]
+}
+```
+
+## Example using different ports
+```json
+[
+    {
+        "name": "Sample-NAD83(2011)",
+        "description": "Service in port 8001 for NAD83(2011)",
+        "urls": [
+            "http://ntrip.example.com:8001"
+        ],
+        "reference": {
+            "url": "http://ntrip.example.com/nad83"
+        },
+        "last_update": "2026-01-23",
+        "streams": [
+            {
+                "filter": "all",
+                "crss": [
+                    {
+                        "id": "EPSG:6319",
+                        "name": "NAD83(2011)",
+                        "epoch": 2010.0
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Sample-NATR2F022",
+        "description": "Service in port 8002 for NATRF2022",
+        "urls": [
+            "http://ntrip.example.com:8002"
+        ],
+        "reference": {
+            "url": "http://ntrip.example.com/natrf2022"
+        },
+        "last_update": "2026-01-23",
+        "streams": [
+            {
+                "filter": "all",
+                "crss": [
+                    {
+                        "id": "EPSG:10967",
+                        "name": "NATRF2022",
+                        "epoch": 2020.0
+                    }
+                ]
+            }
+        ]
+    }
+]
+```


### PR DESCRIPTION
The modernized NSRS https://beta.ngs.noaa.gov is becoming official in the near future.
NTRIP-catalog can help to reduce the chaos, and clearly identify the CRS offered by the providers.

This example tries to show two different use cases. The link to that page can be sent to the providers, helping them to contribute their data.

The text is clearly improvable ;)